### PR TITLE
Feature/uc 003/logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -55,4 +55,13 @@ class AuthController extends Controller
             'user' => $user,
         ]);
     }
+
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json([
+            'message' => 'Logged out successfully.'
+        ]);
+    }
 }

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -4,4 +4,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\AuthController;
 
 Route::post('/register', [AuthController::class, 'register']);
+
 Route::post('/login', [AuthController::class, 'login']);
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+});

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('logs out successfully', function () {
+    $user = User::factory()->create();
+
+    $token = $user->createToken('api-token')->plainTextToken;
+
+    $response = $this->withHeader('Authorization', "Bearer $token")
+                     ->postJson('/api/logout');
+
+    $response->assertStatus(200)
+             ->assertJson([
+                 'message' => 'Logged out successfully.'
+             ]);
+});


### PR DESCRIPTION
POST /api/logout endpoint protected with auth:sanctum middleware.
Controller method that revokes the current access token.
Feature test using Pest to validate logout behavior under real authentication flow.

Include Header  Authorization with value Bearer {token}
You get the token after login in.
