### PR TITLE
Get specific task method and test

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -38,4 +38,21 @@ class TaskController extends Controller
         ]);
     }
 
+    public function getTask(Request $request, Task $task)
+    {
+        if ($task->user_id !== $request->user()->id) {
+            return response()->json(['message' => 'Unauthorized.'], 403);
+        }
+
+        return response()->json([
+            'task' => [
+                'id' => $task->id,
+                'title' => $task->title,
+                'description' => $task->description,
+                'state' => $task->state,
+                'due_date' => $task->due_date,
+            ]
+        ]);
+    }
+
 }

--- a/routes/task.php
+++ b/routes/task.php
@@ -6,4 +6,5 @@ use App\Http\Controllers\TaskController;
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/tasks', [TaskController::class, 'store']);
     Route::get('/tasks', [TaskController::class, 'getAll']);
+    Route::get('/tasks/{task}', [TaskController::class, 'getTask']);
 });

--- a/tests/Feature/Task/GetTaskTest.php
+++ b/tests/Feature/Task/GetTaskTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use function Pest\Laravel\{ getJson , actingAs };
+
+uses(RefreshDatabase::class);
+
+it('shows the details of a task for the authenticated user', function () {
+    $user = User::factory()->create();
+    $task = Task::factory()->for($user)->create([
+        'title' => 'Sample Task',
+        'description' => 'This is a test description.',
+        'state' => 'pending',
+        'due_date' => now()->addDays(5)->toDateString(),
+    ]);
+
+    $response = actingAs($user)->getJson("/api/tasks/{$task->id}");
+
+    $response->assertOk()
+        ->assertJson([
+            'task' => [
+                'id' => $task->id,
+                'title' => 'Sample Task',
+                'description' => 'This is a test description.',
+                'state' => 'pending',
+                'due_date' => $task->due_date,
+            ]
+        ]);
+});
+
+it('returns 403 if the task does not belong to the user', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    $task = Task::factory()->for($user1)->create();
+
+    $response = actingAs($user2)->getJson("/api/tasks/{$task->id}");
+
+    $response->assertStatus(403)
+        ->assertJson([
+            'message' => 'Unauthorized.',
+        ]);
+});
+
+it('returns 401 if the user is not authenticated', function () {
+    $user = User::factory()->create();
+
+    $task = Task::factory()->create([
+        'user_id' => $user->id,
+    ]);
+
+    getJson("/api/tasks/{$task->id}")
+        ->assertStatus(401);
+});
+


### PR DESCRIPTION
GET tasks/{taskId} Endpoint to fetch a task by ID (only if it belongs to the authenticated user)
Task is returned with: id, title, description, due_date, and state
Proper authorization check to prevent access to other users' tasks
Returns 403 if the task belongs to someone else
Returns 401 if the user is unauthenticated