### PR TITLE
Feature/uc 008/delete or complete task

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -75,4 +75,31 @@ class TaskController extends Controller
             'task' => $task->only(['id', 'title', 'description', 'due_date', 'state']),
         ]);
     }
+
+    public function complete(Task $task, Request $request)
+    {
+        if ($task->user_id !== $request->user()->id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $task->update(['state' => 'completed']);
+
+        return response()->json([
+            'message' => 'Task marked as completed.',
+            'task' => $task,
+        ]);
+    }
+
+    public function destroy(Task $task, Request $request)
+    {
+        if ($task->user_id !== $request->user()->id) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+
+        $task->delete();
+
+        return response()->json(['message' => 'Task deleted successfully.']);
+    }
+
+
 }

--- a/routes/task.php
+++ b/routes/task.php
@@ -8,4 +8,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/tasks', [TaskController::class, 'getAll']);
     Route::get('/tasks/{task}', [TaskController::class, 'get']);
     Route::put('/tasks/{task}', [TaskController::class, 'update']);
+    Route::patch('/tasks/{task}', [TaskController::class, 'update']);
+    Route::patch('/tasks/{task}/complete', [TaskController::class, 'complete']);
+    Route::delete('/tasks/{task}', [TaskController::class, 'destroy']);
 });

--- a/tests/Feature/Task/CompleteTaskTest.php
+++ b/tests/Feature/Task/CompleteTaskTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\patchJson;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('marks a task as completed for the authenticated user', function () {
+    $user = User::factory()->create();
+    $task = Task::factory()->create([
+        'user_id' => $user->id,
+        'state' => 'pending',
+    ]);
+
+    actingAs($user)
+        ->patchJson("/api/tasks/{$task->id}/complete")
+        ->assertOk()
+        ->assertJsonFragment([
+            'state' => 'completed',
+        ]);
+});
+
+it('returns 403 if trying to complete another user\'s task', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $task = Task::factory()->create([
+        'user_id' => $otherUser->id,
+        'state' => 'pending',
+    ]);
+
+    actingAs($user)
+        ->patchJson("/api/tasks/{$task->id}/complete")
+        ->assertForbidden();
+});
+
+it('returns 401 if user is not authenticated when completing a task', function () {
+    $task = Task::factory()->create(['user_id' => User::factory()->create()->id]);
+
+    auth()->logout();
+
+    patchJson("/api/tasks/{$task->id}/complete")
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Task/DeleteTaskTest.php
+++ b/tests/Feature/Task/DeleteTaskTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\deleteJson;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('deletes a task for the authenticated user', function () {
+    $user = User::factory()->create();
+    $task = Task::factory()->create(['user_id' => $user->id]);
+
+    actingAs($user)
+        ->deleteJson("/api/tasks/{$task->id}")
+        ->assertOk()
+        ->assertJson([
+            'message' => 'Task deleted successfully.',
+        ]);
+
+    expect(Task::find($task->id))->toBeNull();
+});
+
+
+it('returns 403 if trying to delete another user\'s task', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $task = Task::factory()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    actingAs($user)
+        ->deleteJson("/api/tasks/{$task->id}")
+        ->assertForbidden();
+});
+
+it('returns 401 if user is not authenticated when deleting a task', function () {
+    $task = Task::factory()->create(['user_id' => User::factory()->create()->id]);
+
+    deleteJson("/api/tasks/{$task->id}")
+        ->assertUnauthorized();
+});


### PR DESCRIPTION
This PR adds two new features for authenticated users:

Mark Task as Completed:
Users can mark their tasks as completed using the /api/tasks/{task}/complete endpoint.
Only the owner of the task can perform this action. Unauthorized attempts are rejected.

Delete Task:
Users can delete their own tasks using the /api/tasks/{task} endpoint with the DELETE method.
A JSON message confirms successful deletion.
Unauthorized or unauthenticated access is properly handled.