### PR TITLE
Update metho get tasks to include filtering by state if included

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -27,16 +27,19 @@ class TaskController extends Controller
     
     public function getAll(Request $request)
     {
-        $tasks = $request->user()
-            ->tasks()
-            ->select('id', 'title', 'description', 'state', 'due_date')
-            ->latest()
-            ->get();
-    
+        $query = $request->user()->tasks()->latest();
+
+        if ($request->has('state')) {
+            $query->where('state', $request->query('state'));
+        }
+
+        $tasks = $query->get(['id', 'title', 'description', 'state', 'due_date']);
+
         return response()->json([
             'tasks' => $tasks,
         ]);
     }
+
 
     public function get(Request $request, Task $task)
     {

--- a/tests/Feature/Task/GetTasksTest.php
+++ b/tests/Feature/Task/GetTasksTest.php
@@ -1,31 +1,54 @@
 <?php
 
-use App\Models\User;
 use App\Models\Task;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use function Pest\Laravel\{ getJson , actingAs };
+use function Pest\Laravel\getJson;
 
 uses(RefreshDatabase::class);
 
-it('returns a list of the authenticated user\'s tasks', function () {
+it('filters tasks by pending state', function () {
     $user = User::factory()->create();
-    Task::factory()->count(5)->create(['user_id' => $user->id]);
-    Task::factory()->count(3)->create(['user_id' => User::factory()]);
 
-    $response = actingAs($user)->getJson('/api/tasks');
+    Task::factory()->count(2)->for($user)->create(['state' => 'pending']);
+    Task::factory()->count(1)->for($user)->create(['state' => 'completed']);
 
-    $response->assertOk();
-    $response->assertJsonCount(5, 'tasks');
-
-    $response->assertJsonStructure([
-        'tasks' => [
-            '*' => ['id', 'title', 'description', 'state', 'due_date'],
-        ],
-    ]);
+    actingAs($user)
+        ->getJson('/api/tasks?state=pending')
+        ->assertOk()
+        ->assertJsonCount(2, 'tasks')
+        ->assertJsonFragment(['state' => 'pending']);
 });
 
-it('denies access if user is not authenticated', function () {
-    $response = getJson('/api/tasks');
+it('filters tasks by completed state', function () {
+    $user = User::factory()->create();
 
-    $response->assertUnauthorized();
+    Task::factory()->count(3)->for($user)->create(['state' => 'completed']);
+    Task::factory()->count(2)->for($user)->create(['state' => 'pending']);
+
+    actingAs($user)
+        ->getJson('/api/tasks?state=completed')
+        ->assertOk()
+        ->assertJsonCount(3, 'tasks')
+        ->assertJsonFragment(['state' => 'completed']);
+});
+
+it('returns all tasks if no state is provided', function () {
+    $user = User::factory()->create();
+
+    Task::factory()->count(2)->for($user)->create(['state' => 'pending']);
+    Task::factory()->count(3)->for($user)->create(['state' => 'completed']);
+
+    actingAs($user)
+        ->getJson('/api/tasks')
+        ->assertOk()
+        ->assertJsonCount(5, 'tasks');
+});
+
+it('denies access to unauthenticated users when filtering', function () {
+    $response = getJson('/api/tasks?state=pending');
+
+    $response->assertUnauthorized(); // o ->assertStatus(401);
 });


### PR DESCRIPTION
Updated the getAll method in the TaskController to allow filtering using a state query parameter.

Returns only the tasks that match the requested state.

If no state is provided, all tasks for the authenticated user are returned.